### PR TITLE
Added a compile script for CSSE2010 markdown notes

### DIFF
--- a/uni/CSSE2010/LectureNotes/concat.sh
+++ b/uni/CSSE2010/LectureNotes/concat.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "" > concat_notes.md
+echo "" > botch
+for i in {1..25}
+do
+	cat "Lec${i}.md" >> concat_notes.md
+done	
+
+pandoc -o CSSE2010_Lecture_Notes.tex concat_notes.md -H botch
+pdflatex CSSE2010_Lecture_Notes.tex
+
+rm concat_notes.md


### PR DESCRIPTION
Botched pandoc script to convert the notes into a .tex file, you can do what you want from there. 

Only issue is that some of the images in the markdown files are html <img> tags, which doesn't get registered correctly in the pandoc conversion is seems.